### PR TITLE
feat: make loading Tailwind blocks optional via `blocks` config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,11 +13,13 @@ export default (editor, opts = {}) => {
       cover: `.object-cover { filter: sepia(1) hue-rotate(190deg) opacity(.46) grayscale(.7) !important; }`,
       changeThemeText: 'Change Theme',
       openCategory: 'Blog',
+      blocks: true
     }, ...opts
   };
 
   // Add blocks
-  loadBlocks(editor, options);
+  if(options.blocks)
+   loadBlocks(editor, options);
   // Add commands
   loadCommands(editor, options);
   // Load i18n files


### PR DESCRIPTION
### Summary
This pull request adds a new blocks option to the plugin configuration, allowing developers to control whether the default Tailwind blocks should be loaded into the GrapesJS editor.

### Details
Introduced a blocks key in the plugin's default options (defaults to true)

If a user sets blocks: false when initializing the plugin, the default Tailwind blocks will not be loaded

This gives developers more flexibility and prevents unwanted blocks from being added when using custom configurations

### Motivation
Sometimes developers prefer to use their own block setup or want to keep the block panel clean. With this change, they now have the option to opt out of the default Tailwind blocks.

### Example usage:

```
pluginsOpts: {
        'grapesjs-tailwind': { 
        blocks: false, // disables loading the default Tailwind blocks
        /* other options */
         }
      }
```